### PR TITLE
Added Ticketing page. Listed some Miniconf types, added links to Kubecon alternatives.

### DIFF
--- a/miniconfs.md
+++ b/miniconfs.md
@@ -150,9 +150,9 @@ prohibited from finding their own funding to assist potential speakers.
 ## Some Alternative Models
 
 * Around KubeCon NA 2019
-** [Cloud Native Rejekts](https://cloud-native.rejekts.io/) offers attendees a weekend of ‘unaccepted’ talks leading into KubeCon. It provides a stage for some of the 85% of talks rejected by KubeCon. Runs on Sat 16th & Sun 17th. Seperate Registration, Website and Organisers
-** [Day Zero co-locationed events](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-events/) at Kubecon. Around 30 co-located conferences running on Monday 18. Main conf on Tues 20th - Thurs 21st. Registered as part of Main Conf, Additional Cost.
-*** [Companies hosting co-located events must be a sponsor](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-best-practices/)
+ * [Cloud Native Rejekts](https://cloud-native.rejekts.io/) offers attendees a weekend of ‘unaccepted’ talks leading into KubeCon. It provides a stage for some of the 85% of talks rejected by KubeCon. Runs on Sat 16th & Sun 17th. Seperate Registration, Website and Organisers
+ * [Day Zero co-locationed events](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-events/) at Kubecon. Around 30 co-located conferences running on Monday 18. Main conf on Tues 20th - Thurs 21st. Registered as part of Main Conf, Additional Cost.
+  * [Companies hosting co-located events must be a sponsor](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-best-practices/)
 
 ## Options  
 

--- a/miniconfs.md
+++ b/miniconfs.md
@@ -2,6 +2,15 @@
 
 ## What are Miniconfs? 
 
+### Main Models
+
+Miniconfs can be run in several ways:
+
+* Like a standard conference with Speakers and talk slots
+* As an unconference
+* A project day (eg Open Hardware) 
+* A big tutorial day
+
 ## What is the history of Miniconfs? Why are they the way they are currently? 
 
 ### Early Miniconfs
@@ -138,7 +147,14 @@ prohibited from finding their own funding to assist potential speakers.
 
 ## Key issues 
 
-## Options 
+## Some Alternative Models
+
+* Around KubeCon NA 2019
+** [Cloud Native Rejekts](https://cloud-native.rejekts.io/) offers attendees a weekend of ‘unaccepted’ talks leading into KubeCon. It provides a stage for some of the 85% of talks rejected by KubeCon. Runs on Sat 16th & Sun 17th. Seperate Registration, Website and Organisers
+** [Day Zero co-locationed events](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-events/) at Kubecon. Around 30 co-located conferences running on Monday 18. Main conf on Tues 20th - Thurs 21st. Registered as part of Main Conf, Additional Cost.
+*** [Companies hosting co-located events must be a sponsor](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-best-practices/)
+
+## Options  
 
 ### Blergh blergh option 1 
 

--- a/miniconfs.md
+++ b/miniconfs.md
@@ -150,9 +150,9 @@ prohibited from finding their own funding to assist potential speakers.
 ## Some Alternative Models
 
 * Around KubeCon NA 2019
- * [Cloud Native Rejekts](https://cloud-native.rejekts.io/) offers attendees a weekend of ‘unaccepted’ talks leading into KubeCon. It provides a stage for some of the 85% of talks rejected by KubeCon. Runs on Sat 16th & Sun 17th. Seperate Registration, Website and Organisers
- * [Day Zero co-locationed events](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-events/) at Kubecon. Around 30 co-located conferences running on Monday 18. Main conf on Tues 20th - Thurs 21st. Registered as part of Main Conf, Additional Cost.
-  * [Companies hosting co-located events must be a sponsor](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-best-practices/)
+  * [Cloud Native Rejekts](https://cloud-native.rejekts.io/) offers attendees a weekend of ‘unaccepted’ talks leading into KubeCon. It provides a stage for some of the 85% of talks rejected by KubeCon. Runs on Sat 16th & Sun 17th. Seperate Registration, Website and Organisers
+  * [Day Zero co-locationed events](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-events/) at Kubecon. Around 30 co-located conferences running on Monday 18. Main conf on Tues 20th - Thurs 21st. Registered as part of Main Conf, Additional Cost.
+    * [Companies hosting co-located events must be a sponsor](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/co-located-best-practices/)
 
 ## Options  
 

--- a/tickets.md
+++ b/tickets.md
@@ -1,0 +1,63 @@
+# Tickets
+
+## What are the tickets
+
+* Contributor - The Contributor ticket is designed for those who wish to attend linux.conf.au as a Professional delegate, as well as supporting the conference by contributing financially. In recognition of this support, Contributors have the option to get their logo and a link to their organisation published on the Contributors page.
+* Professional - The Professional ticket is the standard full inclusion conference ticket. This rate applies to most people who have their companies pay the conference fees, or for individuals who can otherwise afford to support the conference at this level.
+* Hobbyist - The Hobbyist rate is heavily discounted for open source enthusiasts who are paying out of their own pockets and would otherwise find it difficult to attend.
+* Student - This is a concession rate ticket that is reserved for High School, College, TAFE or University Students. linux.conf.au offers this rate as a form of investment in the future of the free and open source software community. As part of the registration process, a valid student ID card or proof of enrolment must be presented to the onsite registration desk. Any Student who cannot provide this will be required to register as a hobbyist by paying the difference in fees between the Student rate and the Hobbyist rate.
+* Volunteers - Requires person to help out
+* Speakers - Professional plus invite to Speaker's dinner
+* Miniconf Organiser - Same as Speaker
+* Media - Same as professional
+* Sponsors - Sponsors get tickets as part of package.
+
+Price ( from 2020 )
+
+* Contributor - $1999
+* Professional - $1099
+* Hobbyist - $549
+* Student - $199
+* Volunteers, Speakers, Miniconf Organisers, Media - Free
+* Sponsors - Varies but starts at over $2000
+
+Note: tickets are discounted by around 20% during earlybird period.
+
+## Other Costs
+
+
+## Grants to Speakers and other attendees
+
+
+## Key issues 
+
+* Professional price is double Hobbyist with relatively few extras
+* The Hobbyist price is perceived to be high by some.
+
+
+## Options  
+
+### Blergh blergh option 1 
+
+#### Pros of $OPTION
+
+#### Drawbacks of $OPTION 
+
+#### Interdependencies of $OPTION
+
+#### Consequences of adopting $OPTION 
+
+## Recommendations 
+
+### Blergh blergh recommendation 1
+
+#### How would this recommendation improve 
+
+- the community 
+- the linux.conf.au event 
+- Linux Australia 
+
+#### Stakeholders affected by recommendation and how they are affected
+
+#### Bottom line budget impact of recommendation 
+

--- a/tickets.md
+++ b/tickets.md
@@ -1,5 +1,9 @@
 # Tickets
 
+There are several types of tickets for Linux.conf.au 
+
+The relative pricing of tickets is aiming at [Price discrimination](https://en.wikipedia.org/wiki/Price_discrimination) to ensure people who can afford it part more but the conference is still accessable for those with less ability to pay.
+
 ## What are the tickets
 
 * Contributor - The Contributor ticket is designed for those who wish to attend linux.conf.au as a Professional delegate, as well as supporting the conference by contributing financially. In recognition of this support, Contributors have the option to get their logo and a link to their organisation published on the Contributors page.


### PR DESCRIPTION
* Just got the ticketing page started with current ticket types.
* Added in the 4 most common Miniconfs we have now
* Added in some bits from Kubecon. Their "day zero" events are a **lot** more commercial to organise.